### PR TITLE
refactor: QA 변경 사항 반영

### DIFF
--- a/app/(base)/talents/[slug]/_components/IntroduceCard.tsx
+++ b/app/(base)/talents/[slug]/_components/IntroduceCard.tsx
@@ -21,91 +21,67 @@ type IntroduceCardProps = {
   job?: string | null;
   skills?: string[];
   className?: string;
-
-  /** 🔹 리스트 전용 옵션들 */
-  /** 이름 오른쪽에 조회수 표기 (예: 245) */
   viewCount?: number;
-  /** 상세 페이지 경로. slug만 주면 /talents/[slug] 로 만듭니다 */
   detailHref?: string;
   slug?: string;
-  /** 연락처 노출 여부 (기본 true). 리스트에선 false로 넘기세요 */
   showContacts?: boolean;
-  /** 상세 버튼 텍스트 (기본: "상세 보기") */
   ctaLabel?: string;
-  // ✅ 리스트 전용: 간단소개 (탐색 페이지에서만 넘겨줌)
   summary?: string;
-  showSummary?: boolean; // 기본 true
+  showSummary?: boolean;
 };
 
-export default async function IntroduceCard({
-  name,
-  profileImageUrl,
-  badges = [],
-  tendencies = [],
-  phone,
-  email,
-  university,
-  major,
-  jobGroup,
-  job,
-  skills = [],
-  className = "",
-  // 리스트 전용
-  viewCount,
-  detailHref,
-  slug,
-  showContacts = true,
-  ctaLabel = "상세 보기",
-  summary,
-  showSummary = true,
-}: IntroduceCardProps) {
+export default async function IntroduceCard(props: IntroduceCardProps) {
+  const {
+    name,
+    profileImageUrl,
+    badges = [],
+    tendencies = [],
+    phone,
+    email,
+    university,
+    major,
+    jobGroup,
+    job,
+    skills = [],
+    className = "",
+    detailHref,
+    slug,
+    showContacts = true,
+    ctaLabel = "상세 보기",
+    summary,
+    showSummary = true,
+  } = props;
+
   const src = profileImageUrl || "/images/default-profile.png";
   const href = detailHref ?? (slug ? `/talents/${slug}` : undefined);
 
-  return (
+  // ▶ 카드 내부 UI를 하나의 JSX로 묶음
+  const CardBody = (
     <section
       className={`w-[910px] mx-auto mb-6 rounded-2xl shadow-[0px_1px_2px_rgba(0,0,0,0.06),0px_1px_3px_rgba(0,0,0,0.10)] bg-white p-8 ${className}`}
     >
       <div className="flex items-start gap-[88px]">
-        {/* 왼쪽: 프로필 이미지 + 상세 버튼 */}
+        {/* 왼쪽: 프로필 + 버튼 자리 */}
         <div className="shrink-0">
           <div className="w-40 h-48 relative rounded-md overflow-hidden bg-[#F5F5F5] border border-border-quaternary">
             <Image src={src} alt={`${name} 프로필 이미지`} fill className="object-cover" priority />
           </div>
 
-          {/* 🔸 리스트: 상세 보기 버튼 */}
+          {/* ↳ 래퍼가 Link일 땐 중첩 a 방지 위해 span으로 표시 */}
           {href && (
-            <Link
-              href={href}
-              className="mt-3 block h-10 w-40 rounded-md bg-[#FF6000] text-white text-center leading-10 font-semibold hover:opacity-90 transition"
+            <span
+              className="mt-3 block h-10 w-40 rounded-md bg-[#FF6000] text-white text-center leading-10 font-semibold
+                         hover:opacity-90 transition"
             >
               {ctaLabel}
-            </Link>
+            </span>
           )}
         </div>
 
         {/* 오른쪽: 본문 */}
         <div className="flex-1 min-w-0 mb-4">
-          {/* 이름 / (조회수 슬롯) / 배지들 */}
           <div className="flex items-center gap-3 flex-wrap">
             <h2 className="text-[18px] sm:text-[20px] font-bold text-black">{name}</h2>
-
-            {/* ✅ 조회수 슬롯: 값 없으면 invisible로 가려 '자리만' 유지 */}
-            <span
-              className={[
-                "flex items-center gap-1 text-[13px] text-[#666]",
-                viewCount == null ? "invisible" : "",
-              ].join(" ")}
-              aria-hidden={viewCount == null}
-            >
-              <span className="text-[#666]">조회수</span>
-              {/* 폭 역동성 줄이려고 tabular-nums + min-w 지정 */}
-              <span className="tabular-nums min-w-8 text-center">
-                {(viewCount ?? 0).toLocaleString()}
-              </span>
-            </span>
-
-            {/* ✅ 배지는 항상 노출 */}
             {badges.length > 0 && (
               <div className="flex flex-wrap gap-3">
                 {badges.map((b) => (
@@ -115,15 +91,14 @@ export default async function IntroduceCard({
             )}
           </div>
 
-          {/* 성향 칩 */}
           {tendencies.length > 0 && <Slider items={tendencies} className="mt-4" />}
-          {/* ✅ 리스트 전용: 간단소개 (summary가 있을 때만) */}
+
           {showSummary && !!summary && (
             <p
-              className="mt-4 text-[14px] leading-6 text-[#111]"
+              className="mt-4 text-[14px] leading-6 text-[#111] border-none outline-none bg-transparent"
               style={{
                 display: "-webkit-box",
-                WebkitLineClamp: 2, // 2줄 말줄임
+                WebkitLineClamp: 3,
                 WebkitBoxOrient: "vertical",
                 overflow: "hidden",
               }}
@@ -132,28 +107,23 @@ export default async function IntroduceCard({
             </p>
           )}
 
-          {/* 연락처 (옵션) */}
           {showContacts && (phone || email) && (
             <div className="mt-4 flex items-center gap-12 text-[14px] text-black">
               {phone && (
-                <a
-                  href={`tel:${phone.replace(/\s+/g, "")}`}
-                  className="flex items-center gap-2 hover:opacity-80"
-                >
+                <span className="flex items-center gap-2">
                   <Image src="/icons/solid-phone.svg" alt="phone" width={16} height={16} />
                   <span>{phone}</span>
-                </a>
+                </span>
               )}
               {email && (
-                <a href={`mailto:${email}`} className="flex items-center gap-2 hover:opacity-80">
+                <span className="flex items-center gap-2">
                   <Image src="/icons/solid-mail.svg" alt="mail" width={16} height={16} />
                   <span>{email}</span>
-                </a>
+                </span>
               )}
             </div>
           )}
 
-          {/* 학교 / 전공 / 직무 */}
           {(university || major || job || jobGroup) && (
             <div className="mt-6 flex flex-col gap-2 text-[14px]">
               {(university || major) && (
@@ -175,7 +145,6 @@ export default async function IntroduceCard({
             </div>
           )}
 
-          {/* 스킬 */}
           {skills.length > 0 && (
             <div className="mt-4 flex items-start gap-10">
               <span className="text-[#888] w-[72px]">스킬</span>
@@ -185,5 +154,18 @@ export default async function IntroduceCard({
         </div>
       </div>
     </section>
+  );
+
+  // ▶ href가 있으면 카드 전체를 Link로 감싼다
+  return href ? (
+    <Link
+      href={href}
+      aria-label={`${name} 상세 페이지로 이동`}
+      className="block rounded-2xl" // 🔸 focus:ring 관련 클래스 제거
+    >
+      {CardBody}
+    </Link>
+  ) : (
+    CardBody
   );
 }

--- a/app/(base)/talents/[slug]/_components/PorfolioCard.tsx
+++ b/app/(base)/talents/[slug]/_components/PorfolioCard.tsx
@@ -11,7 +11,6 @@ export type PorfolioCardProps = {
 };
 
 export default function PorfolioCard({
-  fileName,
   fileUrl,
   height = 520,
   className = "",
@@ -52,17 +51,6 @@ export default function PorfolioCard({
 
       {/* 본문 */}
       <div className="px-6 pb-6">
-        {/* 파일명 */}
-        <p
-          className={cn(
-            "text-[14px] leading-[1.7] break-all mb-3",
-            fileName ? "text-[#333]" : "text-[#999]"
-          )}
-          title={fileName}
-        >
-          {fileName || "선택된 파일이 없습니다."}
-        </p>
-
         {/* PDF 미리보기 */}
         <div className="w-full rounded-xl border border-border-quaternary bg-white overflow-hidden">
           {fileUrl ? (

--- a/app/(base)/talents/[slug]/_components/ResumeCard.tsx
+++ b/app/(base)/talents/[slug]/_components/ResumeCard.tsx
@@ -86,8 +86,8 @@ export default function ResumeCard({
               간단소개
             </h4>
           </div>
-          <div className="w-full rounded-xl border border-border-quaternary bg-white p-5">
-            <p className="text-[14px] leading-[1.7] text-[#333] whitespace-pre-wrap">
+          <div className="w-full">
+            <p className="mt-1 text-[14px] leading-[1.7] text-[#333] whitespace-pre-wrap">
               {summary || "간단 소개가 없습니다."}
             </p>
           </div>
@@ -160,11 +160,11 @@ export default function ResumeCard({
           )}
         </section>
 
-        {/* 수상 */}
+        {/* 수상 / 활동 / 기타 */}
         <section aria-labelledby="resume-award">
           <div className="py-3 border-t border-border-quaternary">
             <h4 id="resume-award" className="text-[14px] font-semibold text-[#333]">
-              수상
+              수상 / 활동 / 기타
             </h4>
           </div>
 
@@ -177,9 +177,7 @@ export default function ResumeCard({
               {awards.map((a, i) => (
                 <IconCard key={i} icon="/icons/solid-star.svg" alt="award" className="border-0">
                   <div className="text-[14px] font-medium text-[#111]">{a.title}</div>
-                  <div className="text-[13px] text-[#666]">
-                    {a.start} - {a.end}
-                  </div>
+                  <div className="text-[13px] text-[#666]">획득일: {a.start}</div>
                   {a.desc && <p className="text-[13px] text-[#555] mt-1">{a.desc}</p>}
                 </IconCard>
               ))}
@@ -205,9 +203,7 @@ export default function ResumeCard({
                 <IconCard key={i} icon="/icons/solid-globe.svg" alt="language" className="border-0">
                   <div className="grid grid-cols-4 gap-6 text-[13px] text-[#444]">
                     <div className="font-medium">{l.name}</div>
-                    <div>{`${l.start} - ${l.end}`}</div>
-                    <div />
-                    <div />
+                    <div>획득일: {l.start}</div>
                   </div>
                 </IconCard>
               ))}
@@ -238,9 +234,7 @@ export default function ResumeCard({
                 >
                   <div className="grid grid-cols-4 gap-6 text-[13px] text-[#444]">
                     <div className="font-medium">{c.name}</div>
-                    <div>{`${c.start} - ${c.end}`}</div>
-                    <div />
-                    <div />
+                    <div>획득일: {c.start}</div>
                   </div>
                 </IconCard>
               ))}

--- a/app/(base)/talents/page.tsx
+++ b/app/(base)/talents/page.tsx
@@ -45,9 +45,17 @@ export default async function TalentsPage(props: TalentsPageProps) {
       ],
       tendencies: ["속도형", "수직적 문화형", "결과 중심형"],
       skills: ["JavaScript", "TypeScript", "React", "Next.js", "Tailwind CSS", "Zustand"],
-      summary:
-        "저는 문제를 해결하며 가치를 창출하는 프론트엔드 개발자입니다. 학부 시절 프로젝트와 인턴 경험으로...",
+      summary: `
+      저는 문제를 해결하며 가치를 창출하는 프론트엔드 개발자입니다.
+      사용자 경험을 최우선으로 고려하며, 복잡한 UI를 효율적이고 유지보수 가능한 구조로 만드는 것에 관심이 많습니다.
+      협업 과정에서 커뮤니케이션을 중시하며, 디자이너 및 백엔드 개발자와의 긴밀한 협업을 통해 더 나은 제품을 만드는 것을 즐깁니다.
+      최근에는 성능 최적화와 접근성 개선, 그리고 디자인 시스템 구축에도 깊은 관심을 두고 있습니다.asdfasdfasdff
+      fffffffffffffffffffffffffffffffffff.
+      fffffffffffffffffffffffffffffasdfasdfasdfa
+      sdfasdfasdfasdfasdfasdf
+    `,
     },
+    // 나머지 항목은 그대로
     {
       slug: "kim-yujin",
       name: "김유진",

--- a/app/(base)/talents/register/_components/QualificationComponent.tsx
+++ b/app/(base)/talents/register/_components/QualificationComponent.tsx
@@ -10,7 +10,7 @@ export default function QualificationComponent() {
     <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       {/* 섹션 타이틀 */}
       <div className="text-[18px] font-bold text-text-primary mb-4 flex items-center gap-1">
-        <span>수상 / 자격증 / 기타</span>
+        <span>수상 / 활동 / 기타</span>
       </div>
 
       {/* 1. 수상 / 활동 */}

--- a/app/(base)/talents/register/_components/section/CertificateSection.tsx
+++ b/app/(base)/talents/register/_components/section/CertificateSection.tsx
@@ -67,7 +67,7 @@ export default function CertificateSection() {
             <div />
             <div>
               <Input
-                placeholder="0000.mm - 0000.mm(0년 0개월)"
+                placeholder="0000.mm"
                 type="text"
                 className="w-full"
                 value={item.period}

--- a/app/(base)/talents/register/_components/section/LanguageSection.tsx
+++ b/app/(base)/talents/register/_components/section/LanguageSection.tsx
@@ -67,7 +67,7 @@ export default function LanguageSection() {
             <div />
             <div>
               <Input
-                placeholder="0000.mm - 0000.mm(0년 0개월)"
+                placeholder="0000.mm"
                 type="text"
                 className="w-full"
                 value={item.period}

--- a/app/(base)/talents/register/_components/section/PremierSection.tsx
+++ b/app/(base)/talents/register/_components/section/PremierSection.tsx
@@ -67,7 +67,7 @@ export default function PremierSection() {
             <div />
             <div className="mb-3">
               <Input
-                placeholder="0000.mm - 0000.mm(0년 0개월)"
+                placeholder="0000.mm"
                 type="text"
                 className="w-full"
                 value={item.period}

--- a/app/(base)/talents/register/_components/section/RegisterJob.tsx
+++ b/app/(base)/talents/register/_components/section/RegisterJob.tsx
@@ -38,6 +38,7 @@ export default function RegisterJob() {
         </div>
         <div className="flex items-center h-12 text-[16px] font-semibold text-text-primary">
           직군 및 직무 선택
+          <span className="text-status-error">*</span>
         </div>
 
         <div />


### PR DESCRIPTION
## ✨ 작업 개요

QA 변경 사항 확인

## ✅ 상세 내용

* 인재 탐색 페이지

- [x] 프로필 조회수 없애기 (단, 프론트 단에서만 없애고 백단에서 DB는 남기기)
- [x] 자기소개 세 줄 표시
- [x] ‘학교 · 전공’, ‘직군 · 직무’ (슬레시 말고 중간 점으로 변경)

* 인재 상세 페이지

- [x] 이름과 뱃지 사이의 간격 조정
- [x] ‘간단소개’ 박스의 윤곽선 제거
- [x] ‘수상 / 활동 / 기타’
- [x] ‘수상 / 활동 / 기타’, ‘언어’, ‘자격증’ 기간을 날짜로 변경
- [x] 포트폴리오 파일명 제거
- [x] 프로필 박스를 클릭해도 ‘인제 상세 페이지’로 넘어가게 수정

* 인재 등록 페이지

- [x] ‘수상 / 활동 / 기타’
- [x] 수상 / 활동 / 기타’, ‘언어’, ‘자격증’ 기간을 날짜로 변경
- [x] ‘직군 직무 선택’이 필수 입력처럼 보이게 별표 처리 (피그마 참고)

## 📸 스크린샷 (선택)

* 인재 등록 페이지

<img width="1503" height="182" alt="image" src="https://github.com/user-attachments/assets/45c51929-99f0-43d1-a5ce-af895dfe9506" />


<img width="1525" height="765" alt="image" src="https://github.com/user-attachments/assets/c6b970cf-a254-42c9-b47a-82d3abde1454" />

* 인재 탐색 페이지

<img width="1674" height="792" alt="image" src="https://github.com/user-attachments/assets/c244e7da-bbdc-4d1d-a0d1-a62c007db9a9" />


* 인재 상세 페이지

<img width="1503" height="536" alt="image" src="https://github.com/user-attachments/assets/a8939b80-39b1-4d5e-8871-f9d242e96484" />

<img width="1195" height="862" alt="image" src="https://github.com/user-attachments/assets/82579940-be97-4257-8fea-5a26f947dd60" />

<img width="1288" height="376" alt="image" src="https://github.com/user-attachments/assets/dba8e6fc-35c3-4331-9be5-a28461cd68d4" />

<img width="1290" height="778" alt="image" src="https://github.com/user-attachments/assets/b731784a-2ac1-4aa5-8ecf-ec9609c9e416" />


## 🧪 확인 사항

-   [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

- 목록 제거 휴지통, 원티드 API 적용은 API 연동할 때 같이할 예정입니다.
## 이슈 관리

close #42 
