### PR TITLE
[feat/#97] 인증 쿠키 설정 및 삭제 기능 서버액션으로 추가, 로그인 및 로그아웃 후 처리 로직 개선

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+/**
+ * 인증 쿠키 설정 Server Action
+ * - 서버에서 Set-Cookie 헤더로 쿠키 설정
+ * - HttpOnly, Secure 플래그 적용으로 보안 강화
+ * - 클라이언트 쿠키 설정 타이밍 이슈 해결
+ *
+ * @param roles - 사용자 역할 배열
+ */
+export async function setAuthCookies(roles: string[]) {
+  const cookieStore = await cookies();
+
+  cookieStore.set("user-roles", JSON.stringify(roles), {
+    httpOnly: true, // XSS 공격 방지
+    secure: process.env.NODE_ENV === "production", // HTTPS에서만 전송
+    sameSite: "lax", // CSRF 공격 방지
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7, // 7일
+  });
+}
+
+/**
+ * 인증 쿠키 삭제 Server Action
+ * - 로그아웃 시 호출
+ */
+export async function clearAuthCookies() {
+  const cookieStore = await cookies();
+
+  cookieStore.delete("user-roles");
+}


### PR DESCRIPTION
## ✨ 작업 개요

ex. 로그인 페이지 레이아웃 구현

## ✅ 상세 내용
### 인증 서버 액션 (actions/auth.ts)
- HttpOnly, Secure 플래그를 적용한 역할 쿠키 설정 Server Action (`setAuthCookies`)
  - XSS 공격 방지 (HttpOnly)
  - HTTPS에서만 전송 (Secure)
  - CSRF 공격 방지 (SameSite: lax)
  - 7일 유효기간 설정
- 로그아웃 시 역할 쿠키 삭제 Server Action (`clearAuthCookies`)

### 로그인 폼 컴포넌트 (app/(auth)/_components/LoginForm.tsx)
- useEffect 기반 로그인 후처리를 useLogin의 onSuccess 콜백으로 리팩토링
- Server Action을 통한 역할 쿠키 설정 추가
- `router.refresh()` 호출로 서버 컴포넌트 캐시 갱신
- 쿠키 설정 완료 후 리다이렉트하여 타이밍 이슈 해결
- 불필요한 useEffect 및 reset 로직 제거

### 로그인 훅 (hooks/auth/useLogin.ts)
- 외부에서 onSuccess 콜백을 주입받을 수 있도록 옵션 파라미터 추가
- 클라이언트 쿠키 설정(`setUserRolesCookie`) 제거
- 쿠키 설정 및 리다이렉트 제어를 외부 콜백으로 위임
- JSDoc 주석 업데이트 (Server Action 기반 쿠키 설정 명시)

### 로그아웃 훅 (hooks/auth/useLogout.ts)
- 클라이언트 쿠키 삭제(`clearUserRolesCookie`) 대신 Server Action(`clearAuthCookies`) 사용
- `router.refresh()` 호출로 서버 컴포넌트 캐시 갱신
- 에러 발생 시에도 쿠키 삭제 및 캐시 갱신 처리
- onSuccess와 onError 핸들러를 async 함수로 변경


close #97 
