### PR TITLE
[feat/#111] 이력서 작성의 임시저장버튼 유효성 검증 로직

### DIFF
--- a/app/(member)/profile/[profileId]/_components/TalentRegisterNav.tsx
+++ b/app/(member)/profile/[profileId]/_components/TalentRegisterNav.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/utils/utils";
 import { useToastStore } from "@/store/toastStore";
 import { useRouter } from "next/navigation";
 import { useFormContext, useWatch } from "react-hook-form";
+import { talentRegisterTempSaveSchema } from "@/schemas/talent/talentRegisterSchema";
 
 interface TalentRegisterNavProps extends React.HTMLAttributes<HTMLElement> {
   onTempSave?: () => void;
@@ -22,7 +23,7 @@ export default function TalentRegisterNav({
 }: TalentRegisterNavProps) {
   const { showToast } = useToastStore();
   const router = useRouter();
-  const { register, control } = useFormContext();
+  const { register, control, getValues } = useFormContext();
 
   // Watch the title value from the form using useWatch
   const titleValue = useWatch({ control, name: "profile.title" }) || "인재 등록";
@@ -33,6 +34,17 @@ export default function TalentRegisterNav({
 
   const handleTempSave = async () => {
     if (onTempSave) {
+      // 임시저장 전 검증 수행
+      const currentValues = getValues();
+      const validationResult = talentRegisterTempSaveSchema.safeParse(currentValues);
+
+      if (!validationResult.success) {
+        // 첫 번째 에러 메시지 표시
+        const firstError = validationResult.error.issues[0];
+        showToast(firstError.message, "error");
+        return;
+      }
+
       await onTempSave();
       showToast("임시 저장되었습니다!");
     }

--- a/schemas/talent/talentRegisterSchema.ts
+++ b/schemas/talent/talentRegisterSchema.ts
@@ -5,6 +5,179 @@
 
 import { z } from "zod";
 
+/**
+ * 임시저장용 스키마
+ * 각 항목(educations, careers, activities, languages, certificates)은
+ * "전부 입력" 또는 "전부 비어있음" 중 하나여야 함
+ */
+export const talentRegisterTempSaveSchema = z.object({
+  profile: z.object({
+    avatar: z.any().nullable(),
+    name: z.string().optional(),
+    title: z.string().optional(),
+    phone: z.string().optional(),
+    email: z.string().optional(),
+    introduction: z.string().optional(),
+    visibility: z.enum(["PUBLIC", "PRIVATE"]).optional(),
+  }),
+  job: z.object({
+    category: z.string().optional(),
+    role: z.string().optional(),
+    experiences: z.array(z.string()).optional(),
+  }),
+  educations: z
+    .array(
+      z.object({
+        id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+        schoolName: z.string().optional(),
+        major: z.string().optional(),
+        status: z.string().optional(),
+        startDate: z.string().optional(),
+        endDate: z.string().optional(),
+        description: z.string().optional(),
+        degree: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          const hasAnyValue = data.schoolName || data.major || data.status || data.startDate || data.endDate;
+          // 아무 값도 없으면 통과 (비워두기)
+          if (!hasAnyValue) return true;
+          // 하나라도 있으면 필수 필드 모두 입력해야 함
+          const validStatuses = ["ENROLLED", "GRADUATED", "COMPLETED"];
+          return !!(data.schoolName && data.major && data.status && validStatuses.includes(data.status) && data.startDate && data.endDate);
+        },
+        {
+          message: "학력 정보를 입력하려면 학교명, 전공, 졸업상태, 시작일, 종료일을 모두 입력해주세요.",
+        }
+      )
+    )
+    .optional(),
+  careers: z
+    .array(
+      z.object({
+        id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+        companyName: z.string().optional(),
+        department: z.string().optional(),
+        position: z.string().optional(),
+        startDate: z.string().optional(),
+        endDate: z.string().optional(),
+        isCurrent: z.boolean().optional(),
+        description: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          const hasAnyValue = data.companyName || data.department || data.position || data.startDate || data.endDate;
+          // 아무 값도 없으면 통과
+          if (!hasAnyValue) return true;
+          // 하나라도 있으면 필수 필드 모두 입력해야 함
+          return !!(data.companyName && data.position && data.startDate);
+        },
+        {
+          message: "경력 정보를 입력하려면 회사명, 직급, 시작일을 모두 입력해주세요.",
+        }
+      )
+    )
+    .optional(),
+  skills: z.object({
+    main: z
+      .array(
+        z.object({
+          id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+          name: z.string().optional(),
+        })
+      )
+      .optional(),
+  }),
+  activities: z
+    .array(
+      z.object({
+        id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+        title: z.string().optional(),
+        organization: z.string().optional(),
+        awardDate: z.string().optional(),
+        description: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          const hasAnyValue = data.title || data.organization || data.awardDate || data.description;
+          // 아무 값도 없으면 통과
+          if (!hasAnyValue) return true;
+          // 하나라도 있으면 필수 필드 모두 입력해야 함
+          return !!(data.title && data.organization && data.awardDate);
+        },
+        {
+          message: "수상/활동 정보를 입력하려면 제목, 기관, 날짜를 모두 입력해주세요.",
+        }
+      )
+    )
+    .optional(),
+  languages: z
+    .array(
+      z.object({
+        id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+        languageName: z.string().optional(),
+        level: z.string().optional(),
+        issueDate: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          const hasAnyValue = data.languageName || data.level || data.issueDate;
+          // 아무 값도 없으면 통과
+          if (!hasAnyValue) return true;
+          // 하나라도 있으면 필수 필드 모두 입력해야 함
+          return !!(data.languageName && data.level);
+        },
+        {
+          message: "언어 정보를 입력하려면 언어명과 수준을 모두 입력해주세요.",
+        }
+      )
+    )
+    .optional(),
+  certificates: z
+    .array(
+      z.object({
+        id: z.union([z.number(), z.string(), z.undefined()]).optional(),
+        name: z.string().optional(),
+        issuer: z.string().optional(),
+        issueDate: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          const hasAnyValue = data.name || data.issuer || data.issueDate;
+          // 아무 값도 없으면 통과
+          if (!hasAnyValue) return true;
+          // 하나라도 있으면 필수 필드 모두 입력해야 함
+          return !!(data.name && data.issuer && data.issueDate);
+        },
+        {
+          message: "자격증 정보를 입력하려면 자격증명, 발급기관, 발급일을 모두 입력해주세요.",
+        }
+      )
+    )
+    .optional(),
+  links: z
+    .array(
+      z.object({
+        type: z.string().optional(),
+        url: z.string().optional().or(z.literal("")),
+        originalFilename: z.string().optional(),
+        contentType: z.string().optional(),
+        fileSize: z.number().optional(),
+      })
+    )
+    .optional(),
+  portfolio: z.string().optional().or(z.literal("")),
+  portfolioFile: z.any().optional(),
+  likelion: z.object({
+    code: z.string().optional(),
+  }),
+  workDrivenTest: z.record(z.string(), z.number().min(1).max(5)).optional(),
+});
+
+/**
+ * 작성완료용 스키마 (기존 스키마)
+ * 필수 필드들이 모두 입력되어야 함
+ */
 export const talentRegisterSchema = z.object({
   profile: z.object({
     avatar: z.any().nullable(),


### PR DESCRIPTION
## ✨ 작업 개요
이력서 작성의 임시저장버튼 유효성 검증 로직

## ✅ 상세 내용

## 1. 두 개의 스키마 생성

1) `talentRegisterTempSaveSchema` (임시저장용)  
- `educations`, `careers`, `activities`, `languages`, `certificates` 항목에서 **"전부 입력" 또는 "전부 비워두기"** 검증 수행  
- 예: 학력에서 학교명만 입력하고 전공을 비우면 에러 발생

2) `talentRegisterSchema` (작성완료용)  
- 기존과 동일하게 **필수 필드 검증** 수행

---

## 2. 검증 로직 (`refine` 사용)

각 항목마다 아래 조건 만족 필요.

- 학력(educations)
  - 학교명, 전공, 졸업상태, 시작일, 종료일 **모두 입력 OR 모두 비움**

- 경력(careers)
  - 회사명, 직급, 시작일 **모두 입력 OR 모두 비움**

- 수상/활동(activities)
  - 제목, 기관, 날짜 **모두 입력 OR 모두 비움**

- 언어(languages)
  - 언어명, 수준 **모두 입력 OR 모두 비움**

- 자격증(certificates)
  - 자격증명, 발급기관, 발급일 **모두 입력 OR 모두 비움**

---

## 3. `TalentRegisterNav` 수정

### 임시저장 버튼 클릭 시 플로우

1. 현재 폼 값을 가져온다.  
2. `talentRegisterTempSaveSchema`로 검증을 수행한다.  
3. 검증 실패 시:
   - 첫 번째 에러 메시지를 토스트로 표시한다.
   - **임시저장 중단**.
4. 검증 성공 시:
   - **임시저장 진행**.


## 🙏 기타 참고 사항
이제 사용자가 임시저장을 누르면 각 항목을 완전히 입력했거나 완전히 비워둔 경우에만 저장이 가능하며, 불완전한 입력이 있으면 명확한 에러 메시지가 표시됩니다.

## 이슈 관리

close #111 
