### PR TITLE
[feat/#122] 지원자 목록 페이지 api 연결

### DIFF
--- a/app/(company)/jobs/[jobId]/applicants/_components/ApplicantTable.tsx
+++ b/app/(company)/jobs/[jobId]/applicants/_components/ApplicantTable.tsx
@@ -1,111 +1,24 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
+import { formatDate } from "@/utils/utils";
+import type { CompanyApplicant } from "@/types/jobApplication";
 
-type ApplicantStatus = "지원 접수" | "서류 통과" | "최종 합격" | "불합격";
-
-interface Applicant {
-  id: number;
-  name: string;
-  profileImage: string;
-  position: string;
-  appliedDate: string;
-  status: ApplicantStatus;
+interface ApplicantTableProps {
+  applicants: CompanyApplicant[];
 }
 
-const MOCK_DATA: Applicant[] = [
-  {
-    id: 1,
-    name: "최유진",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "2024. 03. 15",
-    status: "지원 접수",
-  },
-  {
-    id: 2,
-    name: "홍길동",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-  {
-    id: 3,
-    name: "김철수",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-  {
-    id: 4,
-    name: "김하나",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "불합격",
-  },
-  {
-    id: 5,
-    name: "신동엽",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "지원 접수",
-  },
-  {
-    id: 6,
-    name: "류진아",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "지원 접수",
-  },
-  {
-    id: 7,
-    name: "신현준",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "지원 접수",
-  },
-  {
-    id: 8,
-    name: "손동엽",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-  {
-    id: 9,
-    name: "손동엽",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-  {
-    id: 10,
-    name: "손하엽",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-  {
-    id: 11,
-    name: "손동엽",
-    profileImage: "/images/companyLogo.png",
-    position: "주니어 디자이너",
-    appliedDate: "YYYY. MM. DD",
-    status: "서류 통과",
-  },
-];
+export default function ApplicantTable({ applicants }: ApplicantTableProps) {
+  if (applicants.length === 0) {
+    return (
+      <div className="w-full py-16 text-center">
+        <p className="text-neutral-500 text-base font-normal font-['Pretendard']">
+          아직 지원자가 없습니다.
+        </p>
+      </div>
+    );
+  }
 
-export default function ApplicantTable() {
   return (
     <table className="w-full border-collapse">
       <thead>
@@ -125,31 +38,24 @@ export default function ApplicantTable() {
         </tr>
       </thead>
       <tbody>
-        {MOCK_DATA.map((applicant) => (
-          <tr key={applicant.id} className="bg-white border-b-[0.80px] border-neutral-300">
+        {applicants.map((applicant, index) => (
+          <tr key={`${applicant.talentProfileId}-${index}`} className="bg-white border-b-[0.80px] border-neutral-300">
             <td className="px-8 py-4">
               <div className="flex justify-start items-center gap-4">
-                <Image
-                  className="w-6 h-6 relative rounded"
-                  src={applicant.profileImage}
-                  alt={applicant.name}
-                  width={24}
-                  height={24}
-                />
                 <span className="text-neutral-800 text-sm font-normal font-['Pretendard'] leading-5">
-                  {applicant.name}
+                  {applicant.applicantName}
                 </span>
               </div>
             </td>
             <td className="px-8 py-4 text-center text-neutral-800 text-sm font-normal font-['Pretendard'] leading-5">
-              {applicant.position}
+              {applicant.jobGroupName}/{applicant.jobRoleName}
             </td>
             <td className="px-8 py-4 text-center text-neutral-800 text-sm font-normal font-['Pretendard'] leading-5">
-              {applicant.appliedDate}
+              {formatDate(applicant.appliedAt)}
             </td>
             <td className="px-8 py-4 text-center">
               <Link
-                href={`/resumes/${applicant.id}`}
+                href={`/talents/${applicant.talentProfileId}`}
                 className="bg-orange-600 w-[128px] h-[41px] rounded-lg inline-flex justify-center items-center px-5 py-2.5 text-white hover:shadow-[0px_4px_6px_-2px_rgba(255,96,0,0.05),0px_10px_15px_-3px_rgba(255,96,0,0.20)] active:text-neutral-300 text-sm font-bold font-['Pretendard'] leading-5"
               >
                 이력서 바로가기

--- a/app/(company)/jobs/[jobId]/applicants/page.tsx
+++ b/app/(company)/jobs/[jobId]/applicants/page.tsx
@@ -1,16 +1,69 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useParams, useSearchParams } from "next/navigation";
 import Pager from "@/components/Pager";
-import ApplicantStats from "./_components/ApplicantStats";
 import ApplicantTable from "./_components/ApplicantTable";
 import BackButton from "../../../../../components/buttons/BackButton";
+import { fetchJobApplicants } from "@/lib/api/jobPostings";
 
-export default async function ApplicantsPage({ params }: { params: Promise<{ jobId: string }> }) {
+export default function ApplicantsPage() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+
+  const jobId = params.jobId as string;
+  const currentPage = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = 10; // 페이지당 아이템 수
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["jobApplicants", jobId, currentPage],
+    queryFn: () =>
+      fetchJobApplicants(jobId, {
+        page: currentPage - 1, // API는 0-based index
+        size: pageSize,
+        sort: ["appliedAt,desc"], // 최신 지원자부터
+      }),
+    enabled: !!jobId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="w-full min-h-screen bg-white pb-[168px]">
+        <div className="max-w-[1160px] mx-auto px-4 py-8 flex flex-col gap-12">
+          <BackButton />
+          <h1 className="text-2xl font-bold text-neutral-800">지원자 현황</h1>
+          <div className="w-full py-16 text-center">
+            <p className="text-neutral-500 text-base font-normal">로딩 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full min-h-screen bg-white pb-[168px]">
+        <div className="max-w-[1160px] mx-auto px-4 py-8 flex flex-col gap-12">
+          <BackButton />
+          <h1 className="text-2xl font-bold text-neutral-800">지원자 현황</h1>
+          <div className="w-full py-16 text-center">
+            <p className="text-red-500 text-base font-normal">데이터를 불러오는데 실패했습니다.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const applicants = data?.content || [];
+  const totalPages = data?.totalPages || 1;
+
   return (
     <div className="w-full min-h-screen bg-white pb-[168px]">
       <div className="max-w-[1160px] mx-auto px-4 py-8 flex flex-col gap-12">
         <BackButton />
         <h1 className="text-2xl font-bold text-neutral-800">지원자 현황</h1>
-        <ApplicantTable />
-        <Pager currentPage={1} totalPages={1} />
+        <ApplicantTable applicants={applicants} />
+        {totalPages > 1 && <Pager currentPage={currentPage} totalPages={totalPages} pageSize={pageSize} />}
       </div>
     </div>
   );

--- a/constants/api.ts
+++ b/constants/api.ts
@@ -142,6 +142,7 @@ export const API_ENDPOINTS = {
     UNPUBLISH: (jobId: number | string) => `/company/job-postings/${jobId}/unpublish`, // PATCH - 채용공고 게시 취소
     IMAGES_PRESIGN_BULK: "/company/job-postings/images/presign-bulk", // POST - 이미지 프리사인 URL 발급
     IMAGES_UPLOAD_COMPLETE: "/company/job-postings/images", // POST - 이미지 업로드 완료 처리
+    APPLICATIONS: (jobId: number | string) => `/company/job-postings/${jobId}/applications`, // GET - 채용공고 지원자 목록
   },
   // 채용공고 (공개 - 인재)
   JOB_POSTINGS: {

--- a/lib/api/jobPostings.ts
+++ b/lib/api/jobPostings.ts
@@ -17,6 +17,10 @@ import type {
   PublicJobPostingsResponse,
   PublicJobPostingsParams,
 } from "@/types/company-job-posting";
+import type {
+  CompanyApplicantsResponse,
+  JobApplicationsRequest,
+} from "@/types/jobApplication";
 
 export type { Job, JobDetailResponse };
 
@@ -201,4 +205,24 @@ export function fetchPublicJobPostings(
 
   const endpoint = `${API_ENDPOINTS.JOB_POSTINGS.LIST}?${queryParams.toString()}`;
   return get<PublicJobPostingsResponse>(endpoint);
+}
+
+/**
+ * 채용 공고 지원자 목록 조회 API (기업용)
+ */
+export function fetchJobApplicants(
+  jobId: string,
+  params: JobApplicationsRequest
+): Promise<CompanyApplicantsResponse> {
+  const queryParams = new URLSearchParams();
+
+  queryParams.append("page", params.page.toString());
+  queryParams.append("size", params.size.toString());
+
+  if (params.sort && params.sort.length > 0) {
+    params.sort.forEach((s) => queryParams.append("sort", s));
+  }
+
+  const endpoint = `${API_ENDPOINTS.COMPANY_JOB_POSTINGS.APPLICATIONS(jobId)}?${queryParams.toString()}`;
+  return get<CompanyApplicantsResponse>(endpoint);
 }

--- a/types/jobApplication.ts
+++ b/types/jobApplication.ts
@@ -69,3 +69,29 @@ export interface ApplyJobResponse {
   talentProfileId: number;
   status: JobApplicationStatus;
 }
+
+// 기업 - 지원자 정보
+export interface CompanyApplicant {
+  applicantName: string;
+  jobGroupName: string;
+  jobRoleName: string;
+  appliedAt: string; // ISO 8601 날짜 문자열
+  applicationStatus: JobApplicationStatus;
+  talentProfileId: number;
+  talentProfileTitle: string;
+}
+
+// 기업 - 지원자 목록 응답
+export interface CompanyApplicantsResponse {
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+  content: CompanyApplicant[];
+  number: number;
+  sort: Sort;
+  numberOfElements: number;
+  pageable: Pageable;
+  empty: boolean;
+}


### PR DESCRIPTION
## ✨ 작업 개요
ex. 로그인 페이지 레이아웃 구현

## ✅ 상세 내용
### 지원자 목록 페이지 (app/(company)/jobs/[jobId]/applicants/page.tsx)
- 페이지 번호 기반 페이지네이션 (기본 10개 항목)
- 최신 지원 순서로 정렬 (appliedAt, desc)
- 로딩/에러 상태 UI 처리

### 지원자 테이블 컴포넌트 (app/(company)/jobs/[jobId]/applicants/_components/ApplicantTable.tsx)
- 지원자 목록 테이블 UI 구현
- 지원자명, 지원 포지션, 지원 일시, 이력서 바로가기 열 구성
- 지원자 데이터 매핑 및 렌더링
- 이력서 조회 링크 (/talents/{talentProfileId})
- 지원자가 없을 때 빈 상태 메시지 표시

### 지원자 관련 API 엔드포인트 (constants/api.ts)
- 채용공고별 지원자 목록 조회 엔드포인트 추가
- APPLICATIONS: `/company/job-postings/{jobId}/applications` (GET)

### 지원자 조회 API 함수 (lib/api/jobPostings.ts)
- fetchJobApplicants 함수 구현
- 타입 안전성을 위한 CompanyApplicantsResponse 반환 타입 지정

### 지원자 관련 타입 정의 (types/jobApplication.ts)
- CompanyApplicant 인터페이스 추가 (지원자 정보)
  - applicantName: 지원자명
  - jobGroupName: 직무 그룹명
  - jobRoleName: 직무 역할명
  - appliedAt: 지원 일시 (ISO 8601)
  - applicationStatus: 지원 상태
  - talentProfileId: 인재 프로필 ID
  - talentProfileTitle: 인재 프로필 제목
- CompanyApplicantsResponse 인터페이스 추가 (페이징된 지원자 목록 응답)
  - 페이징 정보 (totalPages, totalElements, page, size 등)
  - 지원자 목록 (content 배열)

## 이슈 관리

close #122 
